### PR TITLE
Set file encoding raw by default to properly handle binary files

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,8 @@ function GzipFilter(inputTree, options) {
 
   this.keepUncompressed = options.keepUncompressed;
   this.appendSuffix = options.hasOwnProperty('appendSuffix') ? options.appendSuffix : true;
+  this.inputEncoding = options.inputEncoding || null;
+  this.outputEncoding = options.outputEncoding || null;
 
   if(this.keepUncompressed && !this.appendSuffix) {
     throw new Error('Cannot keep uncompressed files without appending suffix. Filenames would be the same.');

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ function GzipFilter(inputTree, options) {
 
   this.keepUncompressed = options.keepUncompressed;
   this.appendSuffix = options.hasOwnProperty('appendSuffix') ? options.appendSuffix : true;
+  // Default file encoding is raw to handle binary files
   this.inputEncoding = options.inputEncoding || null;
   this.outputEncoding = options.outputEncoding || null;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-gzip",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Broccoli plugin to gzip files.",
   "main": "index.js",
   "author": "Dan Freeman",


### PR DESCRIPTION
Ran into an issue with broccoli-gzip when I'm attempted to gzip text files along with binary files. Since broccoli-gzip doesn't pass a file encoding to broccoli-filter, broccoli-filter handles all files with the default encoding of utf8. As a result, the gzip output is corrupt for binary files. 

I suggest that by default we set the file encoding for files as raw (null) to support manipulation of binary files.